### PR TITLE
Tof

### DIFF
--- a/leaphymicropython/sensors/tof.py
+++ b/leaphymicropython/sensors/tof.py
@@ -1,7 +1,7 @@
 """This module provides time-of-flight related calculations."""  # Single-line docstring
 
 from machine import I2C, Pin
-from vl53l0x import VL53L0X
+from leaphymicropython.sensors.vl53l0x import VL53L0X
 from leaphymicropython.utils.i2c_helper import select_channel
 
 

--- a/leaphymicropython/sensors/tof.py
+++ b/leaphymicropython/sensors/tof.py
@@ -30,6 +30,7 @@ class TimeOfFlight:
         """
         self.channel = channel
         self.i2c = I2C(id=0, scl=Pin(scl_gpio_pin), sda=Pin(sda_gpio_pin))
+        select_channel(self.i2c, self.MULTIPLEXER_ADDRESS, self.channel)
         self.tof = self.initialize_tof()
 
     def initialize_tof(self):


### PR DESCRIPTION
select_channel call fixes the problem when connecting the sensor for the first time.
after select_channel, the sensor is visible via i2c.scan(), before it can not be found.