### PR TITLE
fix: properly map servo values

### DIFF
--- a/leaphymicropython/actuators/servo.py
+++ b/leaphymicropython/actuators/servo.py
@@ -9,7 +9,7 @@ def set_servo_angle(pin: int, angle: int) -> None:
     :param pin: The pin number to which the servo motor is connected
     :param angle: The angle to set the servo motor to
     """
-    if not (0 <= angle <= 180):
+    if not 0 <= angle <= 180:
         raise ValueError("The angle must be between 0 and 180")
 
     pin = pin_to_gpio(pin)

--- a/leaphymicropython/actuators/servo.py
+++ b/leaphymicropython/actuators/servo.py
@@ -9,11 +9,23 @@ def set_servo_angle(pin: int, angle: int) -> None:
     :param pin: The pin number to which the servo motor is connected
     :param angle: The angle to set the servo motor to
     """
+    if not (0 <= angle <= 180):
+        raise ValueError("The angle must be between 0 and 180")
+
     pin = pin_to_gpio(pin)
     pwm = PWM(Pin(pin))
     pwm.freq(50)
-    degrees_in_u16 = (9000 - 2000) / 180
-    duty_cycle = round(9000 - (angle * degrees_in_u16))
-    if not angle > -1 or not angle < 361:
-        raise ValueError("The angle must be in between 0 and 180")
+
+    # Use Arduino's pulse width mapping (544-2400 microseconds)
+    min_pulse = 544
+    max_pulse = 2400
+
+    # Map angle (0-180) to pulse width in microseconds
+    pulse_width = min_pulse + (angle * (max_pulse - min_pulse) / 180)
+
+    # Convert microseconds to 16-bit duty cycle value
+    # 20ms period (50Hz) = 20,000 microseconds
+    # duty_u16 takes a value from 0-65535
+    duty_cycle = int((pulse_width / 20000) * 65535)
+
     pwm.duty_u16(duty_cycle)

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
         ["leaphymicropython/actuators/ssd1306.py", "github:leaphy-robotics/leaphy-micropython/leaphymicropython/actuators/ssd1306.py"]
     ],
     "deps": [],
-    "version": "1.6.0"
+    "version": "1.6.1"
 }


### PR DESCRIPTION
This code is based on arduino's code for the servo library, it properly maps the servo values to the respective duty values to ensure 90 deg is actually 90 deg

this fix is essential for allowing the starling continuous servos to be controlled
